### PR TITLE
Add note to ::re-graph/query example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Dispatch the `init` event to bootstrap it and then use the `:subscribe`, `:unsub
 
 ;; perform a query, with the response sent to the callback event provided
 (re-frame/dispatch [::re-graph/query
+                    :my-query-id         ;; unique id for this query
                     "{ things { id } }"  ;; your graphql query
                     {:some "variable"}   ;; arguments map
                     [::on-thing]])       ;; callback event when response is recieved


### PR DESCRIPTION
It looks like there's some code in `re-graph.internals` which is meant to make the `query-id` parameter to the `::re-graph/query` event optional, but when I tried this out (in ClojureScript) I got console errors when I didn't include the parameter ("Uncaught TypeError: s.replace is not a function" coming up from the depth of re-frame). The code I was running was:

```clojure
(rf/dispatch [::re-graph/query "{ randomFrame { height width pixels } }" nil [::my-callback]])
```

This worked fine:

```clojure
(rf/dispatch [::re-graph/query :foo "{ randomFrame { height width pixels } }" nil [::my-callback]])
```

Possibly there's some kind of bug in the library, but anyways this PR just updates the README to reflect the usage that is working correctly.